### PR TITLE
Fixes #5 byte_dist_per_packet. Found Chris Schulze's source!

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -33,3 +33,9 @@
  * OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+
+/* 
+ * NB: This version modified for Jacobs M51 IoT Classifier: outputs MAC 
+ * addresses and byte_dist_per_packet for up to 10 packets.
+ *
+ */

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ Addendum: For our most recent network fingerprinting tools and data, please see 
 
 ## Jacobs Fork
 
-This fork of Joy makes minor modifications for our machine learning work:
-* Pass source and destination MAC addresses through as unique identifiers.
-* TBD: Byte histograms for the first 5 packets
+This fork of Joy makes minor modifications for our M51 IoT Classifier:
+* Output byte_dist_per_packet: byte histograms for the first 5-10 packets.
+  These are used in the language model (autoencoder with attention).
+* Output sm and dm, source and destination MAC addresses.
+  These provide unique identifiers during training.
+
 
 ## Overview
 

--- a/src/include/p2f.h
+++ b/src/include/p2f.h
@@ -120,6 +120,12 @@ typedef struct mac_addr_ {
     unsigned char bytes[6];
 } mac_addr_t;
 
+// adding struct for storage of byte dist for each packet:
+typedef struct byte_dist_arr_
+{
+    uint32_t byte_count[256];
+} byte_dist_arr_t;
+
 #include "procwatch.h"
 #include "config.h"
 
@@ -135,6 +141,7 @@ extern FILE *info;
 #define MAX_NUM_PKT_LEN 200
 #define MAX_IDP 1500
 #define MAX_TCP_RETRANS_BUFFER 10
+#define MAX_NUM_PKT_BYTE_DIST_ARR 10
 
 typedef struct flow_record_ {
     flow_key_t key;                       /*!< identifies flow by 5-tuple          */
@@ -148,6 +155,7 @@ typedef struct flow_record_ {
 
     mac_addr_t src_mac;                   /*!< Source MAC address                  */
     mac_addr_t dst_mac;                   /*!< Destination MAC address             */
+    byte_dist_arr_t byte_dist_array[MAX_NUM_PKT_BYTE_DIST_ARR]; /* list of byte dist array for each packet*/
 
     struct timeval start;                 /*!< start time                          */ 
     struct timeval end;                   /*!< end time                            */

--- a/src/pkt_proc.c
+++ b/src/pkt_proc.c
@@ -39,6 +39,9 @@
  *
  * \brief packet processing function implementation
  *
+ * \brief this version modified for Jacobs M51 IoT Classifier
+ * to outputs MAC addresses as unique IDs
+ *
  */
 #include <stdio.h>
 #include <pcap.h>


### PR DESCRIPTION
Add byte histograms for the first 5-10 packets: `byte_dist_per_packet`.
Used in the M51 language model.